### PR TITLE
Do not try to put empty item lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,6 +214,9 @@ function mapItems(data) {
 }
 
 function putItems(options, fn) {
+  if (!options.data.Items || options.data.Items.length === 0) {
+    return fn(null, options)
+  }
   var batchWriteItems = {}
   batchWriteItems.RequestItems = {}
   batchWriteItems.RequestItems[options.destination.tableName] = options.data.Items


### PR DESCRIPTION
This fixes a bug when the total number of items to copy is an exact multiple of 25 (which is the page size). Otherwise, at the end of the last page, it tries to put the "next" page of empty items.


If this PR is accepted, I'd very much appreciate a publication of a new version on npm :D