### PR TITLE
Remove unused import from index file

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 var AWS = require('aws-sdk')
 var validate = require('./validate')
 var readline = require('readline')
-var parallel = require('async').parallel;
 
 function copy(values, fn) {
 


### PR DESCRIPTION
This was causing the library to fail with `Error: Cannot find module 'async'`.

I think that import was not meant to be there, it's not being used in the library, nor it's required as a dendency.