### PR TITLE
Use source and destination table names in in-flight output

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ function startCopying(options, fn) {
       if (options.log) {
         readline.clearLine(process.stdout)
         readline.cursorTo(process.stdout, 0)
-        process.stdout.write('Copied ' + options.counter + ' items')
+        process.stdout.write('Copied ' + options.counter + ' items' + ' from ' + options.source.tableName + ' to ' + options.destination.tableName)
       }
 
       if (options.key === undefined) {


### PR DESCRIPTION
I found it useful when running a number of copies in parallel to see the table names that the output count related to. I've therefore created this little PR in case this is something you also think is beneficial.